### PR TITLE
fix instructions and spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ to see the exact expectation:
 
 ```ruby
 describe "all_phrases" do
-  it "takes in an argument and puts out the catch phrase" do
+  it "puts out all of the previous catch phrases" do
     expect{all_phrases}.to output(/It's-a me, Mario!\n/).to_stdout
     expect{all_phrases}.to output(/Thank You Mario! But Our Princess Is In Another Castle!\n/).to_stdout
     expect{all_phrases}.to output(/It's Dangerous To Go Alone! Take This.\n/).to_stdout

--- a/spec/catch_phrases_spec.rb
+++ b/spec/catch_phrases_spec.rb
@@ -19,7 +19,7 @@ describe "link" do
 end
 
 describe "all_phrases" do
-  it "takes in an argument and puts out the catch phrase" do
+  it "puts out all of the previous catch phrases" do
     expect{all_phrases}.to output(/It's-a me, Mario!\n/).to_stdout
     expect{all_phrases}.to output(/Thank You Mario! But Our Princess Is In Another Castle!\n/).to_stdout
     expect{all_phrases}.to output(/It's Dangerous To Go Alone! Take This.\n/).to_stdout


### PR DESCRIPTION
There were some contradicting messages in the spec for the #all_phrases method. 

Now after the fix, the spec message correctly matches the desired method behavior.